### PR TITLE
Update Projection after loading Alignment

### DIFF
--- a/Projector Aligner/ProjectorGroup.cs
+++ b/Projector Aligner/ProjectorGroup.cs
@@ -192,6 +192,7 @@ namespace IngameScript
                 );
                 CurrentProjector.ProjectionRotation = ProjectionRotation;
                 CurrentProjector.ProjectionOffset = ProjectionOffset;
+                CurrentProjector.UpdateOffsetAndRotation();
             }
 
             internal void SaveAlignment()


### PR DESCRIPTION
I noticed after loading alignment from CustomData, the display would update but the projection would not change. Sending an update call to the projector does the trick.